### PR TITLE
URL kwargs --> Query parameters (depth chart and standings views)

### DIFF
--- a/apps/seasons/urls.py
+++ b/apps/seasons/urls.py
@@ -9,6 +9,4 @@ urlpatterns = [
          views.AdvanceSeasonFormView.as_view(), name='advance_season'),
     path('<slug:league>/standings/',
          views.LeagueStandingsView.as_view(), name='league_standings'),
-    path('<slug:league>/standings/<str:entity>/',
-         views.LeagueStandingsView.as_view(), name='league_standings_entity'),
 ]

--- a/apps/teams/urls.py
+++ b/apps/teams/urls.py
@@ -14,6 +14,4 @@ urlpatterns = [
          views.TeamRosterView.as_view(), name='team_roster'),
     path('<slug:league>/teams/<slug:slug>/depth-chart/',
          views.DepthChartView.as_view(), name='depth_chart'),
-    path('<slug:league>/teams/<slug:slug>/depth-chart/<str:position>/',
-         views.DepthChartView.as_view(), name='depth_chart_pos'),
 ]

--- a/apps/teams/views.py
+++ b/apps/teams/views.py
@@ -133,7 +133,7 @@ class DepthChartView(IsLeagueOwner, LeagueTeamsMixin, LeagueContextMixin, Detail
         players = Player.objects.filter(id__in=player_ids)
 
         positions = list(dict.fromkeys([player.position for player in players]))
-        position = self.kwargs.get("position", "QB")
+        position = self.request.GET.get("position", "QB")
 
         if position not in positions:
             raise Http404("Position does not exist")

--- a/templates/seasons/includes/standings_nav.html
+++ b/templates/seasons/includes/standings_nav.html
@@ -9,14 +9,14 @@
 <hr>
 <nav>
   <ul class="pagination pagination d-flex flex-wrap">
-    <li class="page-item{% if not entity %} active" aria-current="page{% endif %}">
-      <a class="page-link" aria-current="page" href="{% url 'seasons:league_standings' league.slug %}">Division</a>
+    <li class="page-item{% if entity == "division" %} active" aria-current="page{% endif %}">
+      <a class="page-link" aria-current="page" href="{% url 'seasons:league_standings' league.slug %}?entity=division">Division</a>
     </li>
     <li class="page-item{% if entity == "conference" %} active" aria-current="page{% endif %}">
-      <a class="page-link" aria-current="page" href="{% url 'seasons:league_standings_entity' league.slug "conference"|urlencode %}">Conference</a>
+      <a class="page-link" aria-current="page" href="{% url 'seasons:league_standings' league.slug %}?entity=conference">Conference</a>
     </li>
     <li class="page-item{% if entity == "power" %} active" aria-current="page{% endif %}">
-      <a class="page-link" aria-current="page" href="{% url 'seasons:league_standings_entity' league.slug "power"|urlencode %}">Power</a>
+      <a class="page-link" aria-current="page" href="{% url 'seasons:league_standings' league.slug %}?entity=power">Power</a>
     </li>
   </ul>
 </nav>

--- a/templates/teams/depth_chart.html
+++ b/templates/teams/depth_chart.html
@@ -39,7 +39,7 @@
   <ul class="pagination pagination-sm d-flex flex-wrap">
     {% for position in positions %}
       <li class="page-item{% if active_position == position %} active" aria-current="page{% endif %}">
-        <a class="page-link" aria-current="page" href="{% url 'teams:depth_chart_pos' league.slug team.slug position|urlencode %}">{{ position }}</a>
+        <a class="page-link" aria-current="page" href="{% url 'teams:depth_chart' league.slug team.slug %}?position={{ position }}">{{ position }}</a>
       </li>
     {% endfor %}
   </ul>


### PR DESCRIPTION
The standings and depth chart views currently use separate URL patterns with kwargs to filter by standings entity (division, conference, etc.) and player position (quarterback, running back, etc.) respectively.

Instead of using a separate URL pattern for this, the new approach uses GET query parameters as filters and simply responds with 404 for invalid ones.